### PR TITLE
Make `Group4Decoder` public

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -150,7 +150,7 @@ impl<E> std::fmt::Display for DecodeError<E> {
 impl<E: std::error::Error> std::error::Error for DecodeError<E> {
 }
 
-struct Group4Decoder<R> {
+pub struct Group4Decoder<R> {
     reader: ByteReader<R>,
     reference: Vec<u16>,
     current: Vec<u16>,


### PR DESCRIPTION
Confirmed that this works with the upstream `image-tiff` crate!

If this is OK, could I get a release tagged as well?