### PR TITLE
chore: bump tiff dev-dependency 0.9 → 0.11.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ debug = []
 fax_derive = { version = "0.2.0", path = "derive" }
 
 [dev-dependencies]
-tiff = { version = "0.9" }
+tiff = { version = "0.11.3" }


### PR DESCRIPTION
## Summary

- Bump `tiff` dev-dependency from 0.9 to 0.11.3

## Test plan

- [x] Dev-dependency only — no effect on library consumers